### PR TITLE
feat: introduce ct command as main entrypoint

### DIFF
--- a/bin/ct
+++ b/bin/ct
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# -----------------------------------------------------------------------------
+# ct (Control Tower)
+#
+# The main entry point for all control-tower commands.
+# This script acts as a router to other specialized scripts.
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+
+# Find the directory where this script is located
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+# Check if any command is provided
+if [ -z "${1:-}" ]; then
+  echo "Error: No command provided." >&2
+  echo "Usage: $0 new story <project-name>" >&2
+  exit 1
+fi
+
+COMMAND=$1 # e.g., "new"
+
+case "$COMMAND" in
+  new)
+    SUB_COMMAND=${2:-} # Safely get the second argument (e.g., "story")
+
+    case "$SUB_COMMAND" in
+      story)
+        PROJECT_NAME=${3:-} # Safely get the third argument (the project name)
+        if [ -z "$PROJECT_NAME" ]; then
+          echo "Error: Project name is required for 'new story'." >&2
+          echo "Usage: $0 new story <project-name>" >&2
+          exit 1
+        fi
+        # Call the script with the validated project name
+        bash "${SCRIPT_DIR}/../scripts/create-story.sh" "$PROJECT_NAME"
+        ;;
+      *)
+        echo "Error: Unknown or missing type for 'new' command. Available: 'story'" >&2
+        echo "Usage: $0 new story <project-name>" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    echo "Error: Unknown command '$COMMAND'. Available: 'new'" >&2
+    echo "Usage: $0 new story <project-name>" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/create-story.sh
+++ b/scripts/create-story.sh
@@ -20,28 +20,21 @@ STORY_FORGE_TEMPLATE_URL="https://github.com/lgpq/story-forge-template.git" # âœ
 
 # --- Main Logic ---
 
-# 1. Check if a project name is provided
-if [ -z "$1" ]; then
-  echo "Error: Project name is required." >&2
-  echo "Usage: $0 <project-name>" >&2
-  exit 1
-fi
+PROJECT_NAME=$1 # The project name is validated and passed from the main 'ct' script.
 
-PROJECT_NAME=$1
+echo "Creating new story project: ${PROJECT_NAME}..."
 
-echo "Creating new story project: $PROJECT_NAME..."
+git clone "$STORY_FORGE_TEMPLATE_URL" "../${PROJECT_NAME}"
 
-git clone "$STORY_FORGE_TEMPLATE_URL" "../$PROJECT_NAME"
-
-PROJECT_PATH="../$PROJECT_NAME" # Define project path for clarity
+PROJECT_PATH="../${PROJECT_NAME}" # Define project path for clarity
 
 echo "Initializing as a new, clean repository..."
 rm -rf "${PROJECT_PATH}/.git"
 
 # Initialize a new git repository
-git -C "$PROJECT_PATH" init -b main
-git -C "$PROJECT_PATH" add .
+git -C "${PROJECT_PATH}" init -b main
+git -C "${PROJECT_PATH}" add .
 # Create the initial commit for the new project
-git -C "$PROJECT_PATH" commit -m "feat: initial commit from story-forge-template"
+git -C "${PROJECT_PATH}" commit -m "feat: initial commit from story-forge-template"
 
 echo "âœ… Successfully created and initialized project: ${PROJECT_NAME}"


### PR DESCRIPTION
Introduces the main `ct` command in the `bin/` directory to act as a centralized entry point for all operations.

This commit also refactors the command handling logic:
- The `ct` script is now responsible for parsing commands, subcommands, and validating all arguments.
- The `scripts/create-story.sh` is simplified to focus solely on its core task, receiving validated arguments from the `ct` command.

This improves robustness by centralizing input validation and makes the system more extensible for future commands.